### PR TITLE
FIXED: Allow Zip64 extensions to be used

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -62,7 +62,8 @@ file
           "Command": "/home/bob/backups/backup-prep-script.sh",
           "Src": "/home/bob/backups/database/mysql_backup.sql",
           "OutputPrefix": "main_db",
-          "PreviousBackupsCount": 2
+          "PreviousBackupsCount": 2,
+          "Zip64": false
         },
         {
           "Name": "Websites Backup",
@@ -77,6 +78,10 @@ If emails are not required, then omit the ``EMAIL_FROM`` and
 
 If the ``PreviousBackupsCount`` is not set, then it will default to keeping
 1 previous backup. It can be set to 0, which will only keep the current backup.
+
+If the ``Zip64`` is not set, then it will default to ``true``. This allows for
+Zip files > 2GB to be created. If running on a old environment this might need to
+be forced to false.
 
 *Note*: When on Windows, it is better to pass the paths using forward
 slashes (/) as then escaping isn’t required (as with backslashes). The

--- a/S3Backup/plan.py
+++ b/S3Backup/plan.py
@@ -32,7 +32,7 @@ import boto.ses
 from S3Backup import hash_file
 
 required_plan_values = ['Name', 'Src', 'OutputPrefix']
-optional_plan_values = ['Command', 'PreviousBackupsCount']
+optional_plan_values = ['Command', 'PreviousBackupsCount', 'Zip64']
 
 logger = logging.getLogger(name='Plan')
 
@@ -56,6 +56,11 @@ class Plan:
             self.previous_backups_count = int(raw_plan['PreviousBackupsCount'])
         else:
             self.previous_backups_count = 1
+
+        if 'Zip64' in raw_plan:
+            self.zip64 = bool(raw_plan['Zip64'])
+        else:
+            self.zip64 = True
 
         self.output_file_prefix = raw_plan['OutputPrefix']
         self.output_file = '%s_%s.zip' % (raw_plan['OutputPrefix'], time.strftime("%Y-%m-%d_%H-%M-%S"))
@@ -138,7 +143,7 @@ class Plan:
 
         logger.info('Outputting to %s', self.output_file)
 
-        with ZipFile(self.output_file, 'w', allowZip64=True) as myzip:
+        with ZipFile(self.output_file, 'w', allowZip64=self.zip64) as myzip:
             for file_name in fileset:
                 try:
                     logger.debug('Adding: %s', file_name)

--- a/S3Backup/plan.py
+++ b/S3Backup/plan.py
@@ -138,7 +138,7 @@ class Plan:
 
         logger.info('Outputting to %s', self.output_file)
 
-        with ZipFile(self.output_file, 'w') as myzip:
+        with ZipFile(self.output_file, 'w', allowZip64=True) as myzip:
             for file_name in fileset:
                 try:
                     logger.debug('Adding: %s', file_name)

--- a/config.json
+++ b/config.json
@@ -12,7 +12,8 @@
       "Command": "mysqldump -u bob -p password > mysql_backup.sql",
       "Src": "c:/mysql_backup.sql",
       "OutputPrefix": "main_db",
-      "PreviousBackupsCount": 2
+      "PreviousBackupsCount": 2,
+      "Zip64": false
     },
 	{
       "Name": "Website Backup",


### PR DESCRIPTION
Allow Zip64 extensions to be used for files larger than 2GB